### PR TITLE
Install as dev dependency instead of regular one

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ expect($el).toHaveClass
 ## Example
 
 ## Installation
+
 ```bash
-yarn add cypress-jest-adapter
+yarn add -D cypress-jest-adapter
 ```
 
 or
 
 ```bash
-npm install --save cypress-jest-adapter
+npm install --save-dev cypress-jest-adapter
 ```
 
 Add `cypress-jest-adapter` to cypress `support/index.js` file


### PR DESCRIPTION
Development dependencies should be installed using as `devDependencies` so they won't be downloaded if you install the project in production